### PR TITLE
feat: add security manifest

### DIFF
--- a/jre/ubuntu-24.04-headless/print-dpkg-query.awk
+++ b/jre/ubuntu-24.04-headless/print-dpkg-query.awk
@@ -1,0 +1,11 @@
+{
+    binary=$1
+    version=$2
+    cmd = "dpkg-query -W -f='${source:Package}\n' " binary "| head -n 1"
+    if ((cmd | getline source) > 0) {
+        print "ii ,"binary":"arch","version","source","version
+    } else {
+        exit 1
+    }
+    close(cmd)
+}

--- a/jre/ubuntu-24.04-headless/rockcraft.yaml
+++ b/jre/ubuntu-24.04-headless/rockcraft.yaml
@@ -151,3 +151,38 @@ parts:
       for tool in java jfr jrunscript jwebserver keytool rmiregistry; do
         ln -s --relative ${JAVA_HOME}/bin/${tool} usr/bin/
       done
+
+  security-manifest:
+    after:
+      - runtime
+      - dependencies
+    plugin: nil
+    source: .
+    build-packages:
+      - zstd
+      - jq
+    override-build: |
+      mkdir -p $CRAFT_PART_INSTALL/usr/share/rocks/
+      FIELDS=(
+          '${db:Status-Abbrev}'
+          '${binary:Package}'
+          '${Version}'
+          '${source:Package}'
+          '${Source:Version}\n'
+        )
+      zstd -d -f -q $CRAFT_STAGE/var/lib/chisel/manifest.wall \
+        -o $CRAFT_PART_BUILD/manifest
+
+      # add openjdk-21 package
+      (
+        IFS="," && \
+        echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+        dpkg-query -f "${FIELDS[*]}" \
+          -W openjdk-21-jdk-headless | head -n 1
+      ) > $CRAFT_PART_INSTALL/usr/share/rocks/dpkg.query
+      # add rest of the packages
+      jq -r 'select(.kind == "package") | "\(.name) \(.version)"' \
+        $CRAFT_PART_BUILD/manifest | \
+        awk -v arch=${CRAFT_ARCH_BUILD_FOR} -F' ' -f print-dpkg-query.awk \
+          >> $CRAFT_PART_INSTALL/usr/share/rocks/dpkg.query
+      craftctl default


### PR DESCRIPTION
Add security manifest as per https://github.com/canonical/oci-factory/blob/main/IMAGE_MAINTAINER_AGREEMENT.md#enable-security-monitoring

The part runs dpkg-query to create the first entry in the security manifest using dpkg-query for openjdk-21-jdk-headless.
Then it unpacks chisel manifest, processes "package" elements to extract name and version and passes them to the awk script to format the manifest in dpkg-query format.

