### PR TITLE
fix: drop base-passwd_data

### DIFF
--- a/jre/ubuntu-24.04-headless/rockcraft.yaml
+++ b/jre/ubuntu-24.04-headless/rockcraft.yaml
@@ -82,7 +82,6 @@ parts:
   dependencies:
     plugin: nil
     stage-packages:
-      - base-passwd_data
       - base-files_base
       - base-files_chisel
       - libc6_libs


### PR DESCRIPTION
This is causing dive efficiency failure in oci-factory, because `run_user` tag is also adding /etc/passwd