### PR TITLE
fix: drop base-passwd_data

### DIFF
--- a/jre/ubuntu-24.04-headless/rockcraft.yaml
+++ b/jre/ubuntu-24.04-headless/rockcraft.yaml
@@ -87,7 +87,6 @@ parts:
   dependencies:
     plugin: nil
     stage-packages:
-      - base-passwd_data
       - base-files_base
       - base-files_chisel
       - libc6_libs


### PR DESCRIPTION
This is causing dive efficiency failure,
because `run_user` tag is also adding /etc/passwd